### PR TITLE
Improve menu editor role checkbox list UX

### DIFF
--- a/nav-menu-roles.php
+++ b/nav-menu-roles.php
@@ -345,7 +345,7 @@ class Nav_Menu_Roles {
 
 		        ?>
 
-		        <div class="role-input-holder" style="float: left; width: 33.3%; margin: 2px 0;">
+		        <div class="role-input-holder" style="margin: 2px 0;">
 		        <input type="checkbox" name="nav-menu-role[<?php echo $item->ID ;?>][<?php echo $i; ?>]" id="nav_menu_role-<?php echo $role; ?>-for-<?php echo $item->ID ;?>" <?php echo $checked; ?> value="<?php echo $role; ?>" />
 		        <label for="nav_menu_role-<?php echo $role; ?>-for-<?php echo $item->ID ;?>">
 		        <?php echo esc_html( $name ); ?>


### PR DESCRIPTION
With a large number (tens and more) of roles, with names of varying length, restricting checkbox element width results in an indecipherable mess of little blocks.

Normal 100% width works much better, probably for everything.